### PR TITLE
PerspectiveProxy and Literal URLs for convenience

### DIFF
--- a/src/Literal.test.ts
+++ b/src/Literal.test.ts
@@ -1,0 +1,24 @@
+import { Literal } from './Literal'
+
+describe("Literal", () => {
+    it("can handle strings", () => {
+        const testString = "test string"
+        const testUrl = "literal://string:test string"
+        expect(Literal.from(testString).toUrl()).toBe(testUrl)
+        expect(Literal.fromUrl(testUrl).get()).toBe(testString)
+    })
+
+    it("can handle numbers", () => {
+        const testNumber = 3.1415
+        const testUrl = "literal://number:3.1415"
+        expect(Literal.from(testNumber).toUrl()).toBe(testUrl)
+        expect(Literal.fromUrl(testUrl).get()).toBe(testNumber)
+    })
+
+    it("can handle objects", () => {
+        const testObject = {testString: "test", testNumber: "1337"}
+        const testUrl = "literal://json:{\"testString\":\"test\",\"testNumber\":\"1337\"}"
+        expect(Literal.from(testObject).toUrl()).toBe(testUrl)
+        expect(Literal.fromUrl(testUrl).get()).toStrictEqual(testObject)
+    })
+})

--- a/src/Literal.ts
+++ b/src/Literal.ts
@@ -1,0 +1,72 @@
+export class Literal {
+    #literal?: any
+    #url?: string
+
+    public static fromUrl(url: string) {
+        if(!url.startsWith("literal://"))
+            throw new Error("Can't create Literal from non-literal URL")
+        const l = new Literal()
+        l.#url = url
+        return l
+    }
+
+    public static from(literal: any) {
+        const l = new Literal()
+        l.#literal = literal
+        return l
+    }
+
+    toUrl(): string {
+        if(this.#url && !this.#literal)
+            return this.#url
+        if(!this.#url && !this.#literal)
+            throw new Error("Can't turn empty Literal into URL")
+
+        let encoded
+        switch(typeof this.#literal) {
+            case 'string':
+                encoded = `string:${this.#literal}`
+                break;
+            case 'number':
+                encoded = `number:${this.#literal}`
+                break;
+            case 'object':
+                encoded = `json:${JSON.stringify(this.#literal)}`
+                break;
+        }
+
+        return `literal://${encoded}`
+    }
+
+    get(): any {
+        if(this.#literal)
+            return this.#literal
+            
+        if(!this.#url)
+            throw new Error("Can't render empty Literal")
+
+        if(!this.#url.startsWith("literal://"))
+            throw new Error("Can't render Literal from non-literal URL")
+
+        // get rid of "literal://"
+        const encoded = this.#url.substring(10)
+
+        if(encoded.startsWith("string:")) {
+            return encoded.substring(7)
+        }
+
+        if(encoded.startsWith("number:")) {
+            const numberString = encoded.substring(7)
+            return parseFloat(numberString)
+        }
+
+        if(encoded.startsWith("json:")) {
+            const json = encoded.substring(5)
+            return JSON.parse(json)
+        }
+
+        throw new Error(`Can't parse unknown literal: ${encoded}`)
+    }
+
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from "./language/LanguageMeta";
 export * from "./links/Links";
 export * from "./perspectives/Perspective";
 export * from "./perspectives/PerspectiveHandle";
+export * from "./perspectives/PerspectiveProxy";
 export * from "./perspectives/LinkQuery";
 export * from "./neighbourhood/Neighbourhood";
 export * from "./typeDefs";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export * from "./language/LanguageContext";
 export * from "./language/LanguageHandle";
 export * from "./language/LanguageMeta";
 export * from "./links/Links";
+export * from "./Literal";
 export * from "./perspectives/Perspective";
 export * from "./perspectives/PerspectiveHandle";
 export * from "./perspectives/PerspectiveProxy";

--- a/src/perspectives/PerspectiveClient.ts
+++ b/src/perspectives/PerspectiveClient.ts
@@ -4,6 +4,7 @@ import unwrapApolloResult from "../unwrapApolloResult";
 import { LinkQuery } from "./LinkQuery";
 import { Perspective } from "./Perspective";
 import { PerspectiveHandle } from "./PerspectiveHandle";
+import { PerspectiveProxy } from './PerspectiveProxy';
 
 const LINK_EXPRESSION_FIELDS = `
 author
@@ -85,7 +86,7 @@ export default class PerspectiveClient {
         })
     }
 
-    async all(): Promise<PerspectiveHandle[]> {
+    async all(): Promise<PerspectiveProxy[]> {
         const { perspectives } = unwrapApolloResult(await this.#apolloClient.query({
             query: gql`query perspectives {
                 perspectives {
@@ -94,10 +95,10 @@ export default class PerspectiveClient {
                 
             }`
         }))
-        return perspectives
+        return perspectives.map(handle => new PerspectiveProxy(handle, this))
     }
 
-    async byUUID(uuid: string): Promise<PerspectiveHandle|null> {
+    async byUUID(uuid: string): Promise<PerspectiveProxy|null> {
         const { perspective } = unwrapApolloResult(await this.#apolloClient.query({
             query: gql`query perspective($uuid: String!) {
                 perspective(uuid: $uuid) {
@@ -106,7 +107,8 @@ export default class PerspectiveClient {
             }`,
             variables: { uuid }
         }))
-        return perspective
+        if(!perspective) return null
+        return new PerspectiveProxy(perspective, this)
     }
 
     async snapshotByUUID(uuid: string): Promise<Perspective|null> {
@@ -133,7 +135,7 @@ export default class PerspectiveClient {
         return perspectiveQueryLinks
     }
 
-    async add(name: string): Promise<PerspectiveHandle> {
+    async add(name: string): Promise<PerspectiveProxy> {
         const { perspectiveAdd } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`mutation perspectiveAdd($name: String!) {
                 perspectiveAdd(name: $name) {
@@ -142,10 +144,10 @@ export default class PerspectiveClient {
             }`,
             variables: { name }
         }))
-        return perspectiveAdd
+        return new PerspectiveProxy(perspectiveAdd, this)
     }
 
-    async update(uuid: string, name: string): Promise<PerspectiveHandle> {
+    async update(uuid: string, name: string): Promise<PerspectiveProxy> {
         const { perspectiveUpdate } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`mutation perspectiveUpdate($uuid: String!, $name: String!) {
                 perspectiveUpdate(uuid: $uuid, name: $name) {
@@ -154,7 +156,7 @@ export default class PerspectiveClient {
             }`,
             variables: { uuid, name }
         }))
-        return perspectiveUpdate
+        return new PerspectiveProxy(perspectiveUpdate, this)
     }
 
     async remove(uuid: string): Promise<{perspectiveRemove: boolean}> {

--- a/src/perspectives/PerspectiveProxy.ts
+++ b/src/perspectives/PerspectiveProxy.ts
@@ -1,0 +1,72 @@
+import PerspectiveClient, { LinkCallback } from "./PerspectiveClient";
+import { Link, LinkExpression } from "../links/Links";
+import { LinkQuery } from "./LinkQuery";
+import { Neighbourhood } from "../neighbourhood/Neighbourhood";
+import { PerspectiveHandle } from './PerspectiveHandle'
+
+export class PerspectiveProxy {
+    #handle: PerspectiveHandle
+    #client: PerspectiveClient
+
+    constructor(handle: PerspectiveHandle, ad4m: PerspectiveClient) {
+        this.#handle = handle
+        this.#client = ad4m
+    }
+
+    get uuid(): string {
+        return this.#handle.uuid
+    }
+
+    get name(): string {
+        return this.#handle.name
+    }
+
+    get sharedUrl(): string|void {
+        return this.#handle.sharedUrl
+    }
+
+    get neighbourhood(): Neighbourhood|void {
+        return this.#handle.neighbourhood
+    }
+
+    async get(query: LinkQuery): Promise<LinkExpression[]> {
+        return await this.#client.queryLinks(this.#handle.uuid, query)
+    }
+
+    async add(link: Link): Promise<LinkExpression> {
+        return await this.#client.addLink(this.#handle.uuid, link)
+    }
+
+    async update(oldLink: LinkExpression, newLink: Link) {
+        return await this.#client.updateLink(this.#handle.uuid, oldLink, newLink)
+    }
+
+    async remove(link: LinkExpression) {
+        return await this.#client.removeLink(this.#handle.uuid, link)
+    }
+
+    async addListener(cb: LinkCallback) {
+        this.#client.addPerspectiveLinkAddedListener(this.#handle.uuid, cb)
+    }
+
+    async removeListener(cb: LinkCallback) {
+        this.#client.addPerspectiveLinkRemovedListener(this.#handle.uuid, cb)
+    }
+
+    async getSingleTarget(query: LinkQuery): Promise<string|void> {
+        delete query.target
+        const foundLinks = await this.get(query)
+        if(foundLinks.length)
+            return foundLinks[0].data.target
+        else
+            return null
+    }
+
+    async setSingleTarget(link: Link) {
+        const query = new LinkQuery({source: link.source, predicate: link.predicate})
+        const foundLinks = await this.get(query)
+        for(const l of foundLinks)
+            await this.remove(l)
+        await this.add(link)
+    }
+}

--- a/src/perspectives/PerspectiveProxy.ts
+++ b/src/perspectives/PerspectiveProxy.ts
@@ -3,6 +3,7 @@ import { Link, LinkExpression } from "../links/Links";
 import { LinkQuery } from "./LinkQuery";
 import { Neighbourhood } from "../neighbourhood/Neighbourhood";
 import { PerspectiveHandle } from './PerspectiveHandle'
+import { Perspective } from "./Perspective";
 
 export class PerspectiveProxy {
     #handle: PerspectiveHandle
@@ -51,6 +52,16 @@ export class PerspectiveProxy {
 
     async removeListener(cb: LinkCallback) {
         this.#client.addPerspectiveLinkRemovedListener(this.#handle.uuid, cb)
+    }
+
+    async snapshot() {
+        return this.#client.snapshotByUUID(this.#handle.uuid)
+    }
+
+    async loadSnapshot(snapshot: Perspective) {
+        for(const link of snapshot.links) {
+            await this.add(link.data)
+        }
     }
 
     async getSingleTarget(query: LinkQuery): Promise<string|void> {


### PR DESCRIPTION
`PerspectiveProxy` is now returned by most functions of `PerspectiveClient`. It's a small wrapper that enables much more readable syntax in clients like:
```js
const perspective = await ad4m.perspective.byUUID('...')
perspective.add(new Link(...))
```
and new convenience functions:
```js
perspective.setSingleTarget(link)
```
which makes sure this new link replaces all links with same source and predicate.

---

`Literal` encodes JS literals (strings, numbers and objects) in URLs - similar to http URL parameters. See tests.