### PR TITLE
Schema type defs are now copied to src/typeDefs.js

### DIFF
--- a/src/buildSchema.ts
+++ b/src/buildSchema.ts
@@ -31,6 +31,7 @@ module.exports = { typeDefsString }
 `
 
     fs.writeFileSync(__dirname+'/typeDefs.js', typeDefsFile)
+    fs.writeFileSync(__dirname+'/src/typeDefs.js', typeDefsFile)
 })
 
 


### PR DESCRIPTION
TypeDefs were being added to only root typeDefs.js file and not src/typeDefs.js