### PR TITLE
Added unsubscribe for addPerspectiveLinkAddedListener & addPerspectiveLinkRemovedListener

### DIFF
--- a/src/Ad4mClient.test.ts
+++ b/src/Ad4mClient.test.ts
@@ -42,6 +42,7 @@ describe('Ad4mClient', () => {
           
 
         const apolloClient = new ApolloClient({
+            // @ts-ignore
             link: ApolloLink.from([errorLink, new HttpLink({ uri: url, fetch})]),
             cache: new InMemoryCache(),
             defaultOptions: {
@@ -368,6 +369,47 @@ describe('Ad4mClient', () => {
             expect(link.data.source).toBe('root')
             expect(link.data.predicate).toBe('p')
             expect(link.data.target).toBe('lang://Qm123')
+        })
+
+        it('addListener() smoke test', async () => {
+            let perspective = await ad4mClient.perspective.byUUID('00004')
+            
+            const linkAdded = jest.fn()
+            const linkRemoved = jest.fn()
+
+            await perspective.addListener('link-added', linkAdded)
+            await perspective.add({source: 'root', target: 'neighbourhood://Qm12345'})  
+
+            expect(linkAdded).toBeCalledTimes(1)
+            expect(linkRemoved).toBeCalledTimes(0)
+
+            perspective = await ad4mClient.perspective.byUUID('00004')
+
+            await perspective.addListener('link-removed', linkRemoved)
+            await perspective.add({source: 'root', target: 'neighbourhood://Qm123456'})  
+
+            expect(linkAdded).toBeCalledTimes(1)
+            expect(linkRemoved).toBeCalledTimes(1)
+        })
+
+        it('removeListener() smoke test', async () => {
+            let perspective = await ad4mClient.perspective.byUUID('00004')
+            
+            const linkAdded = jest.fn()
+
+            await perspective.addListener('link-added', linkAdded)
+            await perspective.add({source: 'root', target: 'neighbourhood://Qm12345'})  
+
+            expect(linkAdded).toBeCalledTimes(1)
+
+            linkAdded.mockClear();
+            
+            perspective = await ad4mClient.perspective.byUUID('00004')
+
+            await perspective.removeListener('link-added', linkAdded)
+            await perspective.add({source: 'root', target: 'neighbourhood://Qm123456'})  
+
+            expect(linkAdded).toBeCalledTimes(0)
         })
 
         it('updateLink() smoke test', async () => {

--- a/src/perspectives/PerspectiveClient.ts
+++ b/src/perspectives/PerspectiveClient.ts
@@ -234,35 +234,39 @@ export default class PerspectiveClient {
         this.#perspectiveRemovedCallbacks.push(cb)
     }
 
-    async addPerspectiveLinkAddedListener(uuid: String, cb: LinkCallback): Promise<void> {
-        this.#apolloClient.subscribe({
-            query: gql` subscription {
-                perspectiveLinkAdded(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
-            }   
-        `}).subscribe({
-            next: result => {
-                //@ts-ignore
-                cb(result.data.perspectiveLinkAdded)
-            },
-            error: (e) => console.error(e)
-        })
+    async addPerspectiveLinkAddedListener(uuid: String, cb: LinkCallback): Promise<ZenObservable.Subscription> {
+        return await new Promise<ZenObservable.Subscription>(resolve => setTimeout(() => {
+            const subscription = this.#apolloClient.subscribe({
+                query: gql` subscription {
+                    perspectiveLinkAdded(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
+                }   
+            `}).subscribe({
+                next: result => {
+                    //@ts-ignore
+                    cb(result.data.perspectiveLinkAdded)
+                },
+                error: (e) => console.error(e)
+            });
 
-        await new Promise<void>(resolve => setTimeout(resolve, 500))
+            resolve(subscription);
+        }, 500));
     }
 
-    async addPerspectiveLinkRemovedListener(uuid: String, cb: LinkCallback): Promise<void> {
-        this.#apolloClient.subscribe({
-            query: gql` subscription {
-                perspectiveLinkRemoved(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
-            }   
-        `}).subscribe({
-            next: result => {
-                //@ts-ignore
-                cb(result.data.perspectiveLinkRemoved)
-            },
-            error: (e) => console.error(e)
-        })
+    async addPerspectiveLinkRemovedListener(uuid: String, cb: LinkCallback): Promise<ZenObservable.Subscription> {
+        return await new Promise<ZenObservable.Subscription>(resolve => setTimeout(() => {
+            const subscription = this.#apolloClient.subscribe({
+                query: gql` subscription {
+                    perspectiveLinkRemoved(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
+                }   
+            `}).subscribe({
+                next: result => {
+                    //@ts-ignore
+                    cb(result.data.perspectiveLinkRemoved)
+                },
+                error: (e) => console.error(e)
+            });
 
-        await new Promise<void>(resolve => setTimeout(resolve, 500))
+            resolve(subscription);
+        }, 500));
     }
 }

--- a/src/perspectives/PerspectiveClient.ts
+++ b/src/perspectives/PerspectiveClient.ts
@@ -234,39 +234,37 @@ export default class PerspectiveClient {
         this.#perspectiveRemovedCallbacks.push(cb)
     }
 
-    async addPerspectiveLinkAddedListener(uuid: String, cb: LinkCallback): Promise<ZenObservable.Subscription> {
-        return await new Promise<ZenObservable.Subscription>(resolve => setTimeout(() => {
-            const subscription = this.#apolloClient.subscribe({
-                query: gql` subscription {
-                    perspectiveLinkAdded(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
-                }   
-            `}).subscribe({
-                next: result => {
-                    //@ts-ignore
-                    cb(result.data.perspectiveLinkAdded)
-                },
-                error: (e) => console.error(e)
-            });
+    async addPerspectiveLinkAddedListener(uuid: String, cb: LinkCallback[]): Promise<void> {
+        this.#apolloClient.subscribe({
+            query: gql` subscription {
+                perspectiveLinkAdded(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
+            }   
+        `}).subscribe({
+            next: result => {
+                cb.forEach(c => {
+                    c(result.data.perspectiveLinkAdded)
+                })
+            },
+            error: (e) => console.error(e)
+        })
 
-            resolve(subscription);
-        }, 500));
+        await new Promise<void>(resolve => setTimeout(resolve, 500))
     }
 
-    async addPerspectiveLinkRemovedListener(uuid: String, cb: LinkCallback): Promise<ZenObservable.Subscription> {
-        return await new Promise<ZenObservable.Subscription>(resolve => setTimeout(() => {
-            const subscription = this.#apolloClient.subscribe({
-                query: gql` subscription {
-                    perspectiveLinkRemoved(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
-                }   
-            `}).subscribe({
-                next: result => {
-                    //@ts-ignore
-                    cb(result.data.perspectiveLinkRemoved)
-                },
-                error: (e) => console.error(e)
-            });
+    async addPerspectiveLinkRemovedListener(uuid: String, cb: LinkCallback[]): Promise<void> {
+        this.#apolloClient.subscribe({
+            query: gql` subscription {
+                perspectiveLinkRemoved(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
+            }   
+        `}).subscribe({
+            next: result => {
+                cb.forEach(c => {
+                    c(result.data.perspectiveLinkRemoved)
+                })
+            },
+            error: (e) => console.error(e)
+        })
 
-            resolve(subscription);
-        }, 500));
+        await new Promise<void>(resolve => setTimeout(resolve, 500))
     }
 }

--- a/src/perspectives/PerspectiveResolver.ts
+++ b/src/perspectives/PerspectiveResolver.ts
@@ -116,11 +116,11 @@ export default class PerspectiveResolver {
 
     @Subscription({topics: "", nullable: true})
     perspectiveLinkAdded(@Arg('uuid') uuid: string): LinkExpression {
-        return new LinkExpression()
+        return testLink
     }
 
     @Subscription({topics: "", nullable: true})
     perspectiveLinkRemoved(@Arg('uuid') uuid: string): LinkExpression {
-        return new LinkExpression()
+        return testLink
     }
 }


### PR DESCRIPTION
`addPerspectiveLinkAddedListener` & `addPerspectiveLinkRemovedListener` now returns apollo subscription object so the consumer of ad4m can unsubscribe the subscriptions.