### PR TITLE
Perspective Client now only has one perspectiveLinkAdded & perspectiveLinkRemoved gql subscription

### DIFF
--- a/src/Ad4mClient.test.ts
+++ b/src/Ad4mClient.test.ts
@@ -379,15 +379,12 @@ describe('Ad4mClient', () => {
 
             await perspective.addListener('link-added', linkAdded)
             await perspective.add({source: 'root', target: 'neighbourhood://Qm12345'})  
-
             expect(linkAdded).toBeCalledTimes(1)
             expect(linkRemoved).toBeCalledTimes(0)
 
             perspective = await ad4mClient.perspective.byUUID('00004')
-
             await perspective.addListener('link-removed', linkRemoved)
             await perspective.add({source: 'root', target: 'neighbourhood://Qm123456'})  
-
             expect(linkAdded).toBeCalledTimes(1)
             expect(linkRemoved).toBeCalledTimes(1)
         })

--- a/src/perspectives/PerspectiveClient.ts
+++ b/src/perspectives/PerspectiveClient.ts
@@ -82,10 +82,8 @@ export default class PerspectiveClient {
         `}).subscribe({
             next: result => {
                 const { link, perspective } = result.data.perspectiveLinkAdded;
-                console.log('haha 0', result.data.perspectiveLinkAdded)
 
                 const links = this.#perspectiveLinkAddedCallbacks.get(perspective.uuid);
-                console.log('haha 1', this.#perspectiveLinkAddedCallbacks)
                 if (links) {
                     links.forEach(c => {
                         c(link)

--- a/src/perspectives/PerspectiveLink.ts
+++ b/src/perspectives/PerspectiveLink.ts
@@ -1,0 +1,20 @@
+import { Field, ObjectType } from "type-graphql";
+import { LinkExpression } from "../links/Links";
+import { PerspectiveHandle } from './PerspectiveHandle'
+
+// This type is used in the GraphQL interface to reference a mutable
+// prespective that is implemented locally by the Ad4m runtime.
+// The UUID is used in mutations to identify the perspective that gets mutated.
+@ObjectType()
+export class PerspectiveLink{
+    @Field(type => LinkExpression)
+    link: LinkExpression
+
+    @Field(type => PerspectiveHandle)
+    perspective: PerspectiveHandle
+
+    constructor(link: LinkExpression, perspective: PerspectiveHandle) {
+        this.link = link
+        this.perspective = perspective
+    }
+}

--- a/src/perspectives/PerspectiveProxy.ts
+++ b/src/perspectives/PerspectiveProxy.ts
@@ -5,21 +5,15 @@ import { Neighbourhood } from "../neighbourhood/Neighbourhood";
 import { PerspectiveHandle } from './PerspectiveHandle'
 import { Perspective } from "./Perspective";
 
-type PerspectiveListenerTypes = "link-added" | "link-removed"
+export type PerspectiveListenerTypes = "link-added" | "link-removed"
 
 export class PerspectiveProxy {
     #handle: PerspectiveHandle
     #client: PerspectiveClient
-    #perspectiveLinkAddedCallbacks: PerspectiveHandleCallback[]
-    #perspectiveLinkRemovedCallbacks: PerspectiveHandleCallback[]
 
     constructor(handle: PerspectiveHandle, ad4m: PerspectiveClient) {
-        this.#perspectiveLinkAddedCallbacks = []
-        this.#perspectiveLinkRemovedCallbacks = []
         this.#handle = handle
         this.#client = ad4m
-        this.#client.addPerspectiveLinkAddedListener(this.#handle.uuid, this.#perspectiveLinkAddedCallbacks)
-        this.#client.addPerspectiveLinkRemovedListener(this.#handle.uuid, this.#perspectiveLinkRemovedCallbacks)
     }
 
     get uuid(): string {
@@ -59,23 +53,11 @@ export class PerspectiveProxy {
     }
 
     async addListener(type: PerspectiveListenerTypes, cb: LinkCallback) {
-        if (type === 'link-added') {
-            this.#perspectiveLinkAddedCallbacks.push(cb);
-        } else if (type === 'link-removed') {
-            this.#perspectiveLinkRemovedCallbacks.push(cb);
-        }
+        await this.#client.addPerspectiveLinkListener(this.#handle.uuid, type, cb);
     }
-
+            
     async removeListener(type: PerspectiveListenerTypes, cb: LinkCallback) {
-        if (type === 'link-added') {
-            const index = this.#perspectiveLinkAddedCallbacks.indexOf(cb);
-    
-            this.#perspectiveLinkAddedCallbacks.splice(index, 1);
-        } else if (type === 'link-removed') {
-            const index = this.#perspectiveLinkRemovedCallbacks.indexOf(cb);
-
-            this.#perspectiveLinkRemovedCallbacks.splice(index, 1);
-        }
+        await this.#client.removePerspectiveLinkListener(this.#handle.uuid, type, cb);
     }
 
     async snapshot() {

--- a/src/perspectives/PerspectiveResolver.ts
+++ b/src/perspectives/PerspectiveResolver.ts
@@ -4,6 +4,7 @@ import { Neighbourhood } from "../neighbourhood/Neighbourhood";
 import { LinkQuery } from "./LinkQuery";
 import { Perspective } from "./Perspective";
 import { PerspectiveHandle } from "./PerspectiveHandle";
+import { PerspectiveLink } from './PerspectiveLink'
 
 const testLink = new LinkExpression()
 testLink.author = "did:ad4m:test"
@@ -115,12 +116,22 @@ export default class PerspectiveResolver {
     }
 
     @Subscription({topics: "", nullable: true})
-    perspectiveLinkAdded(@Arg('uuid') uuid: string): LinkExpression {
-        return testLink
+    perspectiveLinkAdded(): PerspectiveLink {
+        const p = new PerspectiveHandle('00004', 'name')
+        p.name = 'test-perspective-2'
+        p.sharedUrl = 'neighbourhood://Qm12345'
+        p.neighbourhood = new Neighbourhood("language://Qm12345", new Perspective())
+        const pLink = new PerspectiveLink(testLink, p);
+        return pLink
     }
 
     @Subscription({topics: "", nullable: true})
-    perspectiveLinkRemoved(@Arg('uuid') uuid: string): LinkExpression {
-        return testLink
+    perspectiveLinkRemoved(): PerspectiveLink {
+        const p = new PerspectiveHandle('00004', 'name')
+        p.name = 'test-perspective-2'
+        p.sharedUrl = 'neighbourhood://Qm12345'
+        p.neighbourhood = new Neighbourhood("language://Qm12345", new Perspective())
+        const pLink = new PerspectiveLink(testLink, p);
+        return pLink
     }
 }


### PR DESCRIPTION
Callbacks are handled in `PerspectiveClient` using a hashmap and don't create subscriptions for each `PerspectiveProxy`.

Can be used like this:
```js
ad4mClient.perspective.addPerspectiveLinkAddedListener(id, type, callback);

// or

const perspective = await ad4mClient.perspective.byUUID(id);
perspective.addListener(type, callback);
```

@lucksus Do we want to only handle the callbacks within the `PerspectiveProxy`?