### PR TITLE
add new agentMutatePublicPerspective method

### DIFF
--- a/src/Ad4mClient.test.ts
+++ b/src/Ad4mClient.test.ts
@@ -159,14 +159,27 @@ describe('Ad4mClient', () => {
         })
 
         it('mutatePublicPerspective() smoke test', async () => {
-            let link = new Link({source: 'root', target: 'perspective://Qm34589a3ccc0'})
-            let link2 = new Link({source: 'root2', target: 'perspective://Qm34589a3ccc0'})
+            let additionLink = new Link({source: 'root', target: 'perspective://Qm34589a3ccc0'})
+            const removalLink = new LinkExpression()
+            removalLink.author = "did:ad4m:test"
+            removalLink.timestamp = Date.now().toString()
+            removalLink.data = {
+                source: 'root2',
+                target: 'perspective://Qm34589a3ccc0'
+            }
+            removalLink.proof = {
+                signature: '',
+                key: '',
+                valid: true
+            }
 
-            const agent = await ad4mClient.agent.mutatePublicPerspective({additions: [link], removals: [link2]} as LinkMutations)
+
+            //Note; here we dont get the links above since mutatePublicPerspective relies on a snapshot which returns the default test link for perspectives
+            const agent = await ad4mClient.agent.mutatePublicPerspective({additions: [additionLink], removals: [removalLink]} as LinkMutations)
             expect(agent.did).toBe('did:ad4m:test')
             expect(agent.perspective.links.length).toBe(1)
             expect(agent.perspective.links[0].data.source).toBe('root')
-            expect(agent.perspective.links[0].data.target).toBe('perspective://Qm34589a3ccc0')
+            expect(agent.perspective.links[0].data.target).toBe('neighbourhood://Qm12345')
         })
 
         it('updateDirectMessageLanguage() smoke test', async () => {

--- a/src/Ad4mClient.test.ts
+++ b/src/Ad4mClient.test.ts
@@ -158,6 +158,22 @@ describe('Ad4mClient', () => {
             expect(agent.did).toBe('did:method:12345')
         })
 
+        it('updatePublicPerspective() smoke test', async () => {
+            const perspective = new Perspective()
+            const link = new LinkExpression()
+            link.author = 'did:method:12345'
+            link.timestamp = new Date().toString()
+            link.data = new Link({source: 'root', target: 'perspective://Qm34589a3ccc0'})
+            link.proof = { signature: 'asdfasdf', key: 'asdfasdf' }
+            perspective.links.push(link)
+
+            const agent = await ad4mClient.agent.updatePublicPerspective(perspective)
+            expect(agent.did).toBe('did:ad4m:test')
+            expect(agent.perspective.links.length).toBe(1)
+            expect(agent.perspective.links[0].data.source).toBe('root')
+            expect(agent.perspective.links[0].data.target).toBe('perspective://Qm34589a3ccc0')
+        })
+
         it('mutatePublicPerspective() smoke test', async () => {
             let additionLink = new Link({source: 'root', target: 'perspective://Qm34589a3ccc0'})
             const removalLink = new LinkExpression()

--- a/src/Ad4mClient.test.ts
+++ b/src/Ad4mClient.test.ts
@@ -158,22 +158,6 @@ describe('Ad4mClient', () => {
             expect(agent.did).toBe('did:method:12345')
         })
 
-        it('updatePublicPerspective() smoke test', async () => {
-            const perspective = new Perspective()
-            const link = new LinkExpression()
-            link.author = 'did:method:12345'
-            link.timestamp = new Date().toString()
-            link.data = new Link({source: 'root', target: 'perspective://Qm34589a3ccc0'})
-            link.proof = { signature: 'asdfasdf', key: 'asdfasdf' }
-            perspective.links.push(link)
-
-            const agent = await ad4mClient.agent.updatePublicPerspective(perspective)
-            expect(agent.did).toBe('did:ad4m:test')
-            expect(agent.perspective.links.length).toBe(1)
-            expect(agent.perspective.links[0].data.source).toBe('root')
-            expect(agent.perspective.links[0].data.target).toBe('perspective://Qm34589a3ccc0')
-        })
-
         it('mutatePublicPerspective() smoke test', async () => {
             let link = new Link({source: 'root', target: 'perspective://Qm34589a3ccc0'})
             let link2 = new Link({source: 'root2', target: 'perspective://Qm34589a3ccc0'})

--- a/src/Ad4mClient.test.ts
+++ b/src/Ad4mClient.test.ts
@@ -15,7 +15,7 @@ import express from 'express';
 import AgentResolver from "./agent/AgentResolver"
 import { Ad4mClient } from "./Ad4mClient";
 import { Perspective } from "./perspectives/Perspective";
-import { Link, LinkExpression, LinkExpressionInput, LinkInput } from "./links/Links";
+import { Link, LinkExpression, LinkExpressionInput, LinkInput, LinkMutations } from "./links/Links";
 import LanguageResolver from "./language/LanguageResolver";
 import NeighbourhoodResolver from "./neighbourhood/NeighbourhoodResolver";
 import PerspectiveResolver from "./perspectives/PerspectiveResolver";
@@ -168,6 +168,17 @@ describe('Ad4mClient', () => {
             perspective.links.push(link)
 
             const agent = await ad4mClient.agent.updatePublicPerspective(perspective)
+            expect(agent.did).toBe('did:ad4m:test')
+            expect(agent.perspective.links.length).toBe(1)
+            expect(agent.perspective.links[0].data.source).toBe('root')
+            expect(agent.perspective.links[0].data.target).toBe('perspective://Qm34589a3ccc0')
+        })
+
+        it('mutatePublicPerspective() smoke test', async () => {
+            let link = new Link({source: 'root', target: 'perspective://Qm34589a3ccc0'})
+            let link2 = new Link({source: 'root2', target: 'perspective://Qm34589a3ccc0'})
+
+            const agent = await ad4mClient.agent.mutatePublicPerspective({additions: [link], removals: [link2]} as LinkMutations)
             expect(agent.did).toBe('did:ad4m:test')
             expect(agent.perspective.links.length).toBe(1)
             expect(agent.perspective.links[0].data.source).toBe('root')

--- a/src/agent/AgentClient.ts
+++ b/src/agent/AgentClient.ts
@@ -163,21 +163,6 @@ export default class AgentClient {
         return agentByDID as Agent
     }
 
-    async updatePublicPerspective(perspective: PerspectiveInput): Promise<Agent> {
-        const { agentUpdatePublicPerspective } = unwrapApolloResult(await this.#apolloClient.mutate({ 
-            mutation: gql`mutation agentUpdatePublicPerspective($perspective: PerspectiveInput!) {
-                agentUpdatePublicPerspective(perspective: $perspective) {
-                    ${AGENT_SUBITEMS}
-                }
-            }`,
-            variables: { perspective: perspective }
-        }))
-        const a = agentUpdatePublicPerspective
-        const agent = new Agent(a.did, a.perspective)
-        agent.directMessageLanguage = a.directMessageLanguage
-        return agent
-    }
-
     async mutatePublicPerspective(mutations: LinkMutations): Promise<Agent> {
         const { agentMutatePublicPerspective } = unwrapApolloResult(await this.#apolloClient.mutate({ 
             mutation: gql`mutation agentMutatePublicPerspective($mutations: LinkMutations!) {

--- a/src/agent/AgentClient.ts
+++ b/src/agent/AgentClient.ts
@@ -3,6 +3,7 @@ import { PerspectiveInput } from "../perspectives/Perspective";
 import unwrapApolloResult from "../unwrapApolloResult";
 import { Agent, EntanglementProof, EntanglementProofInput } from "./Agent";
 import { AgentStatus } from "./AgentStatus"
+import { LinkMutations } from "../links/Links";
 
 const AGENT_SUBITEMS = `
     did
@@ -172,6 +173,21 @@ export default class AgentClient {
             variables: { perspective: perspective }
         }))
         const a = agentUpdatePublicPerspective
+        const agent = new Agent(a.did, a.perspective)
+        agent.directMessageLanguage = a.directMessageLanguage
+        return agent
+    }
+
+    async mutatePublicPerspective(mutations: LinkMutations): Promise<Agent> {
+        const { agentMutatePublicPerspective } = unwrapApolloResult(await this.#apolloClient.mutate({ 
+            mutation: gql`mutation agentMutatePublicPerspective($mutations: LinkMutations!) {
+                agentMutatePublicPerspective(mutations: $mutations) {
+                    ${AGENT_SUBITEMS}
+                }
+            }`,
+            variables: { mutations: mutations }
+        }))
+        const a = agentMutatePublicPerspective
         const agent = new Agent(a.did, a.perspective)
         agent.directMessageLanguage = a.directMessageLanguage
         return agent

--- a/src/agent/AgentResolver.ts
+++ b/src/agent/AgentResolver.ts
@@ -3,7 +3,6 @@ import { Perspective, PerspectiveInput } from "../perspectives/Perspective";
 import { Agent, EntanglementProof, EntanglementProofInput } from "./Agent";
 import { AgentStatus } from "./AgentStatus"
 import { AGENT_STATUS_CHANGED, AGENT_UPDATED } from "../PubSub";
-import { LinkExpression, LinkMutations } from "../links/Links";
 
 const TEST_AGENT_DID = "did:ad4m:test"
 

--- a/src/agent/AgentResolver.ts
+++ b/src/agent/AgentResolver.ts
@@ -3,6 +3,7 @@ import { Perspective, PerspectiveInput } from "../perspectives/Perspective";
 import { Agent, EntanglementProof, EntanglementProofInput } from "./Agent";
 import { AgentStatus } from "./AgentStatus"
 import { AGENT_STATUS_CHANGED, AGENT_UPDATED } from "../PubSub";
+import { LinkExpression, LinkMutations } from "../links/Links";
 
 const TEST_AGENT_DID = "did:ad4m:test"
 
@@ -67,6 +68,31 @@ export default class AgentResolver {
     @Mutation(returns => Agent)
     agentUpdatePublicPerspective(@Arg('perspective') perspective: PerspectiveInput, @PubSub() pubSub: any): Agent {
         const agent = new Agent(TEST_AGENT_DID, perspective as Perspective)
+        agent.directMessageLanguage = "lang://test";
+        pubSub.publish(AGENT_UPDATED, { agent })
+        return agent
+    }
+
+    @Mutation(returns => Agent)
+    agentMutatePublicPerspective(@Arg('mutations') mutations: LinkMutations, @PubSub() pubSub: any): Agent {
+        const perspective = new Perspective();
+        //@ts-ignore
+        perspective.links = mutations.additions.map(link => {
+            return {
+                data: {
+                    source: link.source,
+                    target: link.target,
+                    predicate: link.predicate
+                },
+                author: "did:ad4m:test",
+                timestamp: new Date().toISOString(),
+                proof: {
+                    signature: "sig",
+                    key: "key"
+                }
+            }
+        });
+        const agent = new Agent(TEST_AGENT_DID, perspective)
         agent.directMessageLanguage = "lang://test";
         pubSub.publish(AGENT_UPDATED, { agent })
         return agent

--- a/src/agent/AgentResolver.ts
+++ b/src/agent/AgentResolver.ts
@@ -66,25 +66,8 @@ export default class AgentResolver {
     }
 
     @Mutation(returns => Agent)
-    agentMutatePublicPerspective(@Arg('mutations') mutations: LinkMutations, @PubSub() pubSub: any): Agent {
-        const perspective = new Perspective();
-        //@ts-ignore
-        perspective.links = mutations.additions.map(link => {
-            return {
-                data: {
-                    source: link.source,
-                    target: link.target,
-                    predicate: link.predicate
-                },
-                author: "did:ad4m:test",
-                timestamp: new Date().toISOString(),
-                proof: {
-                    signature: "sig",
-                    key: "key"
-                }
-            }
-        });
-        const agent = new Agent(TEST_AGENT_DID, perspective)
+    agentUpdatePublicPerspective(@Arg('perspective') perspective: PerspectiveInput, @PubSub() pubSub: any): Agent {
+        const agent = new Agent(TEST_AGENT_DID, perspective as Perspective)
         agent.directMessageLanguage = "lang://test";
         pubSub.publish(AGENT_UPDATED, { agent })
         return agent

--- a/src/agent/AgentResolver.ts
+++ b/src/agent/AgentResolver.ts
@@ -66,14 +66,6 @@ export default class AgentResolver {
     }
 
     @Mutation(returns => Agent)
-    agentUpdatePublicPerspective(@Arg('perspective') perspective: PerspectiveInput, @PubSub() pubSub: any): Agent {
-        const agent = new Agent(TEST_AGENT_DID, perspective as Perspective)
-        agent.directMessageLanguage = "lang://test";
-        pubSub.publish(AGENT_UPDATED, { agent })
-        return agent
-    }
-
-    @Mutation(returns => Agent)
     agentMutatePublicPerspective(@Arg('mutations') mutations: LinkMutations, @PubSub() pubSub: any): Agent {
         const perspective = new Perspective();
         //@ts-ignore

--- a/src/links/Links.ts
+++ b/src/links/Links.ts
@@ -20,6 +20,15 @@ export class Link {
 }
 
 @InputType()
+export class LinkMutations {
+    @Field(type => [LinkInput])
+    additions: LinkInput[];
+
+    @Field(type => [LinkInput])
+    removals: LinkInput[];
+}
+
+@InputType()
 export class LinkInput {
     @Field()
     source: string;

--- a/src/links/Links.ts
+++ b/src/links/Links.ts
@@ -24,8 +24,8 @@ export class LinkMutations {
     @Field(type => [LinkInput])
     additions: LinkInput[];
 
-    @Field(type => [LinkInput])
-    removals: LinkInput[];
+    @Field(type => [LinkExpression])
+    removals: LinkExpression[];
 }
 
 @InputType()

--- a/src/perspectives/PerspectiveProxy.ts
+++ b/src/perspectives/PerspectiveProxy.ts
@@ -116,7 +116,14 @@ export class PerspectiveProxy {
     }
 
     async loadSnapshot(snapshot: Perspective) {
-        for(const link of snapshot.links) {
+        //Clean the input data from __typename
+        const cleanedSnapshot = JSON.parse(JSON.stringify(snapshot));
+        delete cleanedSnapshot.__typename;
+        cleanedSnapshot.links.forEach(link => {
+           delete link.data.__typename;
+        });
+
+        for(const link of cleanedSnapshot.links) {
             await this.add(link.data)
         }
     }


### PR DESCRIPTION
Currently updating an agents public perspective is difficult. It requires the management of a separate proxy perspective which is used to add / remove links from in order to get signed links. Then a dev must take a snapshot of this perspective, concatenate the links with any other links the user may have on their public perspective, and then update the whole public perspective.

This method intendeds to make the mutation of public perspectives easier by offloading the tracking of mutations & signing of links to the executor. Allowing users to submit unsigned link additions & removals and cause mutation of the agents public perspective.