### PR TITLE
changes update() and remove() links to accept expression hash's vs raw LinkExpression objects

### DIFF
--- a/src/Ad4mClient.test.ts
+++ b/src/Ad4mClient.test.ts
@@ -494,7 +494,7 @@ describe('Ad4mClient', () => {
             perspective = await ad4mClient.perspective.byUUID('00004')
 
             await perspective.addListener('link-removed', linkRemoved)
-            await perspective.remove(testLink)  
+            await perspective.remove(testLink.hash.toString())  
 
             expect(linkAdded).toBeCalledTimes(1)
             expect(linkRemoved).toBeCalledTimes(1)
@@ -521,9 +521,21 @@ describe('Ad4mClient', () => {
         })
 
         it('updateLink() smoke test', async () => {
+            const sourceLink = new LinkExpression();
+            sourceLink.author = "did:ad4m:test"
+            sourceLink.timestamp = Date.now().toString()
+            sourceLink.data = {
+                source: 'root',
+                target: 'neighbourhood://Qm12345'
+            }
+            sourceLink.proof = {
+                signature: '',
+                key: '',
+                valid: true
+            }
             const link = await ad4mClient.perspective.updateLink(
                 '00001', 
-                {author: '', timestamp: '', proof: {signature: '', key: ''}, data:{source: 'root', target: 'none'}},
+                sourceLink.hash.toString(),
                 {source: 'root', target: 'lang://Qm123', predicate: 'p'})
             expect(link.author).toBe('did:ad4m:test')
             expect(link.data.source).toBe('root')
@@ -532,7 +544,19 @@ describe('Ad4mClient', () => {
         })
 
         it('removeLink() smoke test', async () => {
-            const r = await ad4mClient.perspective.removeLink('00001', {author: '', timestamp: '', proof: {signature: '', key: ''}, data:{source: 'root', target: 'none'}})
+            const sourceLink = new LinkExpression();
+            sourceLink.author = "did:ad4m:test"
+            sourceLink.timestamp = Date.now().toString()
+            sourceLink.data = {
+                source: 'root',
+                target: 'neighbourhood://Qm12345'
+            }
+            sourceLink.proof = {
+                signature: '',
+                key: '',
+                valid: true
+            }
+            const r = await ad4mClient.perspective.removeLink('00001', sourceLink.hash.toString())
             expect(r).toBeTruthy()
         })
     })

--- a/src/perspectives/PerspectiveClient.ts
+++ b/src/perspectives/PerspectiveClient.ts
@@ -1,5 +1,5 @@
 import { ApolloClient, gql } from "@apollo/client/core";
-import { Link, LinkExpressionInput, LinkExpression, LinkInput } from "../links/Links";
+import { Link, LinkExpression, LinkInput } from "../links/Links";
 import unwrapApolloResult from "../unwrapApolloResult";
 import { LinkQuery } from "./LinkQuery";
 import { Perspective } from "./Perspective";
@@ -167,15 +167,12 @@ export default class PerspectiveClient {
         return perspectiveAddLink
     }
  
-    async updateLink(uuid: string, oldLink: LinkExpressionInput, newLink: LinkInput): Promise<LinkExpression> {
-        delete oldLink.__typename
-        delete oldLink.data.__typename
-        delete oldLink.proof.__typename
+    async updateLink(uuid: string, oldLink: String, newLink: LinkInput): Promise<LinkExpression> {
         const { perspectiveUpdateLink } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`mutation perspectiveUpdateLink(
                 $uuid: String!, 
-                $newLink: LinkInput!
-                $oldLink: LinkExpressionInput!
+                $newLink: LinkInput!,
+                $oldLink: String!
             ){
                 perspectiveUpdateLink(
                     newLink: $newLink, 
@@ -190,12 +187,9 @@ export default class PerspectiveClient {
         return perspectiveUpdateLink
     }
 
-    async removeLink(uuid: string, link: LinkExpressionInput): Promise<{perspectiveRemoveLink: boolean}> {
-        delete link.__typename
-        delete link.data.__typename
-        delete link.proof.__typename
+    async removeLink(uuid: string, link: String): Promise<{perspectiveRemoveLink: boolean}> {
         return unwrapApolloResult(await this.#apolloClient.mutate({
-            mutation: gql`mutation perspectiveRemoveLink($link: LinkExpressionInput!, $uuid: String!) {
+            mutation: gql`mutation perspectiveRemoveLink($link: String!, $uuid: String!) {
                 perspectiveRemoveLink(link: $link, uuid: $uuid)
             }`,
             variables: { uuid, link }
@@ -209,7 +203,7 @@ export default class PerspectiveClient {
 
     subscribePerspectiveAdded() {
         this.#apolloClient.subscribe({
-            query: gql` subscription {
+            query: gql`subscription {
                 perspectiveAdded { ${PERSPECTIVE_HANDLE_FIELDS} }
             }   
         `}).subscribe({
@@ -228,7 +222,7 @@ export default class PerspectiveClient {
 
     subscribePerspectiveUpdated() {
         this.#apolloClient.subscribe({
-            query: gql` subscription {
+            query: gql`subscription {
                 perspectiveUpdated { ${PERSPECTIVE_HANDLE_FIELDS} }
             }   
         `}).subscribe({
@@ -247,7 +241,7 @@ export default class PerspectiveClient {
 
     subscribePerspectiveRemoved() {
         this.#apolloClient.subscribe({
-            query: gql` subscription {
+            query: gql`subscription {
                 perspectiveRemoved
             }   
         `}).subscribe({
@@ -262,7 +256,7 @@ export default class PerspectiveClient {
 
     async addPerspectiveLinkAddedListener(uuid: String, cb: LinkCallback[]): Promise<void> {
         this.#apolloClient.subscribe({
-            query: gql` subscription {
+            query: gql`subscription {
                 perspectiveLinkAdded(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
             }   
         `}).subscribe({
@@ -279,7 +273,7 @@ export default class PerspectiveClient {
 
     async addPerspectiveLinkRemovedListener(uuid: String, cb: LinkCallback[]): Promise<void> {
         this.#apolloClient.subscribe({
-            query: gql` subscription {
+            query: gql`subscription {
                 perspectiveLinkRemoved(uuid: "${uuid}") { ${LINK_EXPRESSION_FIELDS} }
             }   
         `}).subscribe({

--- a/src/perspectives/PerspectiveProxy.ts
+++ b/src/perspectives/PerspectiveProxy.ts
@@ -47,7 +47,7 @@ export class PerspectiveProxy {
                             predicate: replaceThis(command.predicate), 
                             target: replaceThis(command.target)}))
                         for (const linkExpression of linkExpressions) {
-                            await this.remove(linkExpression)
+                            await this.remove(linkExpression.hash.toString())
                         }
                         break;
                 }
@@ -83,11 +83,11 @@ export class PerspectiveProxy {
         return await this.#client.addLink(this.#handle.uuid, link)
     }
 
-    async update(oldLink: LinkExpression, newLink: Link) {
+    async update(oldLink: String, newLink: Link) {
         return await this.#client.updateLink(this.#handle.uuid, oldLink, newLink)
     }
 
-    async remove(link: LinkExpression) {
+    async remove(link: String) {
         return await this.#client.removeLink(this.#handle.uuid, link)
     }
 
@@ -134,10 +134,7 @@ export class PerspectiveProxy {
         const query = new LinkQuery({source: link.source, predicate: link.predicate})
         const foundLinks = await this.get(query)
         for(const l of foundLinks){
-            delete l.__typename
-            delete l.data.__typename
-            delete l.proof.__typename
-            await this.remove(l)
+            await this.remove(l.hash.toString())
         }
             
         await this.add(link)

--- a/src/perspectives/PerspectiveResolver.ts
+++ b/src/perspectives/PerspectiveResolver.ts
@@ -99,7 +99,7 @@ export default class PerspectiveResolver {
     }
  
     @Mutation(returns => LinkExpression)
-    perspectiveUpdateLink(@Arg('uuid') uuid: string, @Arg('oldLink') oldlink: LinkExpressionInput, @Arg('newLink') newlink: LinkInput, @PubSub() pubSub: any): LinkExpression {
+    perspectiveUpdateLink(@Arg('uuid') uuid: string, @Arg('oldLink') oldlink: String, @Arg('newLink') newlink: LinkInput, @PubSub() pubSub: any): LinkExpression {
         const l = new LinkExpression()
         l.author = 'did:ad4m:test'
         l.timestamp = Date.now()
@@ -112,7 +112,7 @@ export default class PerspectiveResolver {
     }
 
     @Mutation(returns => Boolean)
-    perspectiveRemoveLink(@Arg('uuid') uuid: string, @Arg('link') link: LinkExpressionInput, @PubSub() pubSub: any): Boolean {
+    perspectiveRemoveLink(@Arg('uuid') uuid: string, @Arg('link') link: String, @PubSub() pubSub: any): Boolean {
         pubSub.publish(LINK_REMOVED_TOPIC)
         return true
     }


### PR DESCRIPTION
Solves #40.

Since this would make LinkExpression hash's the basis for link mutations, I wonder if it makes sense to permanently include the hash in LinkExpression, vs having it as a method, or perhaps more accurately having an address such as: `link://hash`. 

In the executor the following must be done: another prolog fact for link hash's & local database should fetch and mutate on link hash's not link objects