### PR TITLE
add a way for a language to register timeout references

### DIFF
--- a/src/language/Language.ts
+++ b/src/language/Language.ts
@@ -32,6 +32,8 @@ export interface Language {
     readonly expressionUI?: ExpressionUI;
     readonly settingsUI?: SettingsUI;
 
+    readonly intervals: ReturnType<typeof setInterval>[] | ReturnType<typeof setTimeout> | number[]
+
     // All available interactions this agent could execute on given expression
     interactions(expression: Address): Interaction[];
 }


### PR DESCRIPTION
This allows the executor to correctly teardown languages upon deletion, and ensure that their timeout loops do not continue to run.