### PR TITLE
adds new addLinkExpression method

### DIFF
--- a/src/Ad4mClient.test.ts
+++ b/src/Ad4mClient.test.ts
@@ -492,6 +492,27 @@ describe('Ad4mClient', () => {
             expect(link.data.target).toBe('lang://Qm123')
         })
 
+        it('addLinkExpression() smoke test', async () => {
+            const testLink = new LinkExpression()
+            testLink.author = "did:ad4m:test"
+            testLink.timestamp = Date.now().toString()
+            testLink.data = {
+                source: 'root',
+                target: 'lang://Qm123',
+                predicate: 'p'
+            }
+            testLink.proof = {
+                signature: '',
+                key: '',
+                valid: true
+            }
+            const link = await ad4mClient.perspective.addLinkExpression('00001', testLink);
+            expect(link.author).toBe('did:ad4m:test')
+            expect(link.data.source).toBe('root')
+            expect(link.data.predicate).toBe('p')
+            expect(link.data.target).toBe('lang://Qm123')
+        })
+
         it('addListener() smoke test', async () => {
             let perspective = await ad4mClient.perspective.byUUID('00004')
             

--- a/src/perspectives/PerspectiveClient.ts
+++ b/src/perspectives/PerspectiveClient.ts
@@ -166,6 +166,18 @@ export default class PerspectiveClient {
         }))
         return perspectiveAddLink
     }
+
+    async addLinkExpression(uuid: string, link: LinkExpressionInput): Promise<LinkExpression> {
+        const { perspectiveAddLinkExpression } = unwrapApolloResult(await this.#apolloClient.mutate({
+            mutation: gql`mutation perspectiveAddLinkExpression($uuid: String!, $link: LinkExpressionInput!){
+                perspectiveAddLinkExpression(link: $link, uuid: $uuid) {
+                    ${LINK_EXPRESSION_FIELDS}
+                }
+            }`,
+            variables: { uuid, link }
+        }))
+        return perspectiveAddLinkExpression
+    }
  
     async updateLink(uuid: string, oldLink: LinkExpressionInput, newLink: LinkInput): Promise<LinkExpression> {
         delete oldLink.__typename

--- a/src/perspectives/PerspectiveProxy.ts
+++ b/src/perspectives/PerspectiveProxy.ts
@@ -1,4 +1,4 @@
-import PerspectiveClient, { LinkCallback, PerspectiveHandleCallback } from "./PerspectiveClient";
+import PerspectiveClient, { LinkCallback } from "./PerspectiveClient";
 import { Link, LinkExpression } from "../links/Links";
 import { LinkQuery } from "./LinkQuery";
 import { Neighbourhood } from "../neighbourhood/Neighbourhood";
@@ -83,6 +83,10 @@ export class PerspectiveProxy {
         return await this.#client.addLink(this.#handle.uuid, link)
     }
 
+    async addLinkExpression(link: LinkExpression): Promise<LinkExpression> {
+        return await this.#client.addLinkExpression(this.#handle.uuid, link)
+    }
+
     async update(oldLink: LinkExpression, newLink: Link) {
         return await this.#client.updateLink(this.#handle.uuid, oldLink, newLink)
     }
@@ -124,7 +128,7 @@ export class PerspectiveProxy {
         });
 
         for(const link of cleanedSnapshot.links) {
-            await this.add(link.data)
+            await this.addLinkExpression(link.data)
         }
     }
 

--- a/src/perspectives/PerspectiveResolver.ts
+++ b/src/perspectives/PerspectiveResolver.ts
@@ -97,6 +97,12 @@ export default class PerspectiveResolver {
         pubSub.publish(LINK_ADDED_TOPIC, { link: l })
         return l
     }
+
+    @Mutation(returns => LinkExpression)
+    perspectiveAddLinkExpression(@Arg('uuid') uuid: string, @Arg('link') link: LinkExpressionInput, @PubSub() pubSub: any): LinkExpression {
+        pubSub.publish(LINK_ADDED_TOPIC, { link })
+        return link as LinkExpression
+    }
  
     @Mutation(returns => LinkExpression)
     perspectiveUpdateLink(@Arg('uuid') uuid: string, @Arg('oldLink') oldlink: LinkExpressionInput, @Arg('newLink') newlink: LinkInput, @PubSub() pubSub: any): LinkExpression {


### PR DESCRIPTION
This method was added so that `perspective.loadSnapshot()` can maintain LinkExpression data; signature etc which allows `removeLink()` in `mutatePublicPerspective()` to work correctly. Currently since links are resigned and added, there is no way to retrieve desired removals from the public perspective and then pass to `mutatePublicPerspective()`, since when `mutatePublicPerspective()` loads the agents current snapshot, it will always have new resigned links.
